### PR TITLE
Better way of handling missings, and restore support for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 sudo: false
 language: julia
 julia:
- - 1.0
-# - nightly
+  - "0.7"
+  - "1.0"
+  - "nightly"
+matrix:
+  allow_failures:
+    - julia: "nightly"
+  fast_finish: true
 before_install:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 1.0
+julia 0.7
 
 DataFrames
 Requires

--- a/src/dataframes.jl
+++ b/src/dataframes.jl
@@ -12,9 +12,12 @@ using DataFrames: AbstractDataFrame, DataFrame
 TNT(::DataFrame; optional-args) extracts target and non-target scores from a dataframe.  The optional arhuments encode which colums are used for what purpose. `score` (default `:score`) is the name of the column containing the classifier's scores.  `target` (default `:target`), of type `Bool`, determines whether this is a target score or not.
 """
 function TNT(x::AbstractDataFrame; score=:score, target=:target)
-    t = collect(skipmissing(convert(Array, x[target])))
-    s = collect(skipmissing(convert(Array, x[score])))
-    TNT(s[t], s[.!t])
+    t::Vector = x[target]
+    s::Vector = x[score]
+    row_is_complete::Vector{Bool} = (.!(ismissing.(t))) .* (.!(ismissing.(s)))
+    t_complete::Vector = [t[row_is_complete]...]
+    s_complete::Vector = [s[row_is_complete]...]
+    TNT(s_complete[t_complete], s_complete[.!t_complete])
 end
 
 for f in (:eer, :eerch, :auc, :cllr, :mincllr)


### PR DESCRIPTION
This PR:

1. Implements a better way of handling missings in DataFrames. If either column (target or score) has a missing value in a row, then we drop that row.
2. Restores support for Julia 0.7.
3. Configures Travis to test on Julia 0.7, 1.0, and nightly (with failures allowed on nightly).

You will notice that in `src/dataframes.jl`, I use splatting on lines 18 and 19. This was the only way that I could get the correct eltypes for `t_complete` and `s_complete`. If I used `collect(...)`, then the eltype still ends up as `Union{T, Missing}`. However, when I use splatting, I get the correct eltype `T`. This is important because the struct `TNT` expects to be given arguments of type `Vector{T}` where `T <: Real`. 

cc: @davidavdav @diegozea