### PR TITLE
Delete REQUIRE file and bump version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ROCAnalysis"
 uuid = "f535d66d-59bb-5153-8d2b-ef0a426c6aff"
 repo = "https://github.com/davidavdav/ROCAnalysis.jl.git"
-version = "0.3.0-DEV"
+version = "0.3.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,0 @@
-julia 0.7
-
-DataFrames
-SpecialFunctions
-RecipesBase


### PR DESCRIPTION
Now that this package has a `Project.toml` file, we no longer need a `REQUIRE` file.

This pull request deletes the `REQUIRE` file. It also bumps the version number so that we can register a new release as soon as this PR is merged.

@davidavdav It would be great to get this merged as soon as possible.